### PR TITLE
Fix case of boolean string in boolean example

### DIFF
--- a/examples/boolean_client.py
+++ b/examples/boolean_client.py
@@ -75,7 +75,7 @@ try:
 
 		if (c == 10 or c == 13): 
 			local_state = not local_state
-			brew.publish('local state', local_state)
+			brew.publish('local state', str(local_state).lower())
 			stdscr.addstr(pos_local, pos_state, (str(local_state) + "  ").encode(code))
 
 		stdscr.refresh()


### PR DESCRIPTION
I try "boolean_client.py" with arduino Yun "Spacebrew Boolean" example program. I have some issues since arduino spacebrew library wait for "true" or "false" string at lowercase. Python use "True" and "False" string for boolean. This commit fix it.
